### PR TITLE
get column types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,9 @@
 .rebar
-
 rebar
-
 ebin
-
 priv
-
 .eunit/*
-
 *.swp
-
 *.o
-
 *~
+_build

--- a/src/esqlite3.erl
+++ b/src/esqlite3.erl
@@ -32,6 +32,7 @@
          fetchone/1,
          fetchall/1,
          column_names/1, column_names/2,
+         column_types/1, column_types/2,
          close/1, close/2]).
 
 -export([q/2, q/3, map/3, foreach/3]).
@@ -303,6 +304,18 @@ column_names(Stmt) ->
 column_names(Stmt, Timeout) ->
     Ref = make_ref(),
     ok = esqlite3_nif:column_names(Stmt, Ref, self()),
+    receive_answer(Ref, Timeout).
+
+%% @doc Return the column types of the prepared statement.
+%%
+-spec column_types(statement()) -> tuple(atom()).
+column_types(Stmt) ->
+    column_types(Stmt, ?DEFAULT_TIMEOUT).
+
+-spec column_types(statement(), timeout()) -> tuple(atom()).
+column_types(Stmt, Timeout) ->
+    Ref = make_ref(),
+    ok = esqlite3_nif:column_types(Stmt, Ref, self()),
     receive_answer(Ref, Timeout).
 
 %% @doc Close the database

--- a/src/esqlite3_nif.erl
+++ b/src/esqlite3_nif.erl
@@ -32,6 +32,7 @@
     finalize/3,
     bind/4,
     column_names/3,
+    column_types/3,
     close/3
 ]).
 
@@ -114,6 +115,12 @@ bind(_Stmt, _Ref, _Dest, _Args) ->
 %%
 %% @spec column_names(statement(), reference(), pid()) -> {ok, tuple()} | {error, message()} 
 column_names(_Stmt, _Ref, _Dest) ->
+    exit(nif_library_not_loaded).
+
+%% @doc Retrieve the column types of the prepared statement
+%%
+%% @spec column_types(statement(), reference(), pid()) -> {ok, tuple()} | {error, message()} 
+column_types(_Stmt, _Ref, _Dest) ->
     exit(nif_library_not_loaded).
 
 %% @doc Close the connection.

--- a/test/esqlite_test.erl
+++ b/test/esqlite_test.erl
@@ -180,6 +180,26 @@ column_names_test() ->
 
     ok.
 
+column_types_test() ->
+    {ok, Db} = esqlite3:open(":memory:"),
+    ok = esqlite3:exec("begin;", Db),
+    ok = esqlite3:exec("create table test_table(one varchar(10), two int);", Db),
+    ok = esqlite3:exec(["insert into test_table values(", "\"hello1\"", ",", "10" ");"], Db),
+    ok = esqlite3:exec(["insert into test_table values(", "\"hello2\"", ",", "20" ");"], Db),
+    ok = esqlite3:exec("commit;", Db),
+
+    %% All columns
+    {ok, Stmt} = esqlite3:prepare("select * from test_table", Db),
+    {'varchar(10)', int} =  esqlite3:column_types(Stmt),
+    {row, {<<"hello1">>, 10}} = esqlite3:step(Stmt),
+    {'varchar(10)', int} =  esqlite3:column_types(Stmt),
+    {row, {<<"hello2">>, 20}} = esqlite3:step(Stmt),
+    {'varchar(10)', int} =  esqlite3:column_types(Stmt),
+    '$done' = esqlite3:step(Stmt),
+    {'varchar(10)', int} =  esqlite3:column_types(Stmt),
+
+    ok.
+
 reset_test() ->
     {ok, Db} = esqlite3:open(":memory:"),
 


### PR DESCRIPTION
Adds `esqlite3:column_types/1` and `esqlite3:column_types/2`.

I wanted to get the column types for a Statement so that I could do some generic typecasting (ie. "2015-01-25 20:32:11.123456" => `{{2015,1,25},{20,32,11}}`)