### PR TITLE
fixes column types error

### DIFF
--- a/c_src/esqlite3_nif.c
+++ b/c_src/esqlite3_nif.c
@@ -587,8 +587,7 @@ do_column_types(ErlNifEnv *env, sqlite3_stmt *stmt)
     for(i = 0; i < size; i++) {
         type = sqlite3_column_decltype(stmt, i);
         if(type == NULL) {
-            free(array);
-            return make_error_tuple(env, "sqlite3_malloc_failure");
+	    type = "nil";
         }
 
         array[i] = make_atom(env, type);

--- a/test/esqlite_test.erl
+++ b/test/esqlite_test.erl
@@ -200,6 +200,16 @@ column_types_test() ->
 
     ok.
 
+nil_column_types_test() ->
+    {ok, Db} = esqlite3:open(":memory:"),
+    ok = esqlite3:exec("begin;", Db),
+    ok = esqlite3:exec("create table t1(c1 variant);", Db),
+    ok = esqlite3:exec("commit;", Db),
+
+    {ok, Stmt} = esqlite3:prepare("select c1 + 1, c1 from t1", Db),
+    {nil, variant} =  esqlite3:column_types(Stmt),
+    ok.
+
 reset_test() ->
     {ok, Db} = esqlite3:open(":memory:"),
 


### PR DESCRIPTION
According to the [man page](https://www.sqlite.org/c3ref/column_decltype.html), `sqlite3_column_decltype()` can return `NULL` pointers for expressions or subqueries (or if the column type is undefined due to SQLite's manifest typing) which should not be treated as errors.