### PR TITLE
Fix for sqlite3_column_count() return check

### DIFF
--- a/c_src/esqlite3_nif.c
+++ b/c_src/esqlite3_nif.c
@@ -546,8 +546,10 @@ do_column_names(ErlNifEnv *env, sqlite3_stmt *stmt)
     ERL_NIF_TERM column_names;
      
     size = sqlite3_column_count(stmt);
-    if(size <= 0)
-        return make_error_tuple(env, "no_columns");
+    if(size == 0)
+        return enif_make_tuple(env, 0);
+    else if(size < 0)
+        return make_error_tuple(env, "invalid_column_count");
 
     array = (ERL_NIF_TERM *) malloc(sizeof(ERL_NIF_TERM) * size);
     if(!array)
@@ -577,8 +579,10 @@ do_column_types(ErlNifEnv *env, sqlite3_stmt *stmt)
     ERL_NIF_TERM column_types;
      
     size = sqlite3_column_count(stmt);
-    if(size <= 0)
-        return make_error_tuple(env, "no_columns");
+    if(size == 0)
+        return enif_make_tuple(env, 0);
+    else if(size < 0)
+        return make_error_tuple(env, "invalid_column_count");
 
     array = (ERL_NIF_TERM *) malloc(sizeof(ERL_NIF_TERM) * size);
     if(!array)

--- a/test/esqlite_test.erl
+++ b/test/esqlite_test.erl
@@ -178,6 +178,10 @@ column_names_test() ->
     {row, {Date}} = esqlite3:step(Stmt4),
     true = is_binary(Date),
 
+    %% Some statements have no column names
+    {ok, Stmt5} = esqlite3:prepare("create table dummy(a, b, c);", Db),
+    {} = esqlite3:column_names(Stmt5),
+
     ok.
 
 column_types_test() ->
@@ -197,6 +201,10 @@ column_types_test() ->
     {'varchar(10)', int} =  esqlite3:column_types(Stmt),
     '$done' = esqlite3:step(Stmt),
     {'varchar(10)', int} =  esqlite3:column_types(Stmt),
+
+    %% Some statements have no column types
+    {ok, Stmt2} = esqlite3:prepare("create table dummy(a, b, c);", Db),
+    {} = esqlite3:column_types(Stmt2),
 
     ok.
 


### PR DESCRIPTION
[The SQLite documentation](https://sqlite.org/c3ref/column_count.html) states that `sqlite3_column_count()` may return 0 for SQL statements that do not return rows.  This update no longer treats this as an error condition.