### PR TITLE
compiles for OTP 18.0

### DIFF
--- a/src/esqlite3.erl
+++ b/src/esqlite3.erl
@@ -296,11 +296,11 @@ bind(Stmt, Args, Timeout) ->
 
 %% @doc Return the column names of the prepared statement.
 %%
--spec column_names(statement()) -> tuple(atom()).
+-spec column_names(statement()) -> {atom()}.
 column_names(Stmt) ->
     column_names(Stmt, ?DEFAULT_TIMEOUT).
 
--spec column_names(statement(), timeout()) -> tuple(atom()).
+-spec column_names(statement(), timeout()) -> {atom()}.
 column_names(Stmt, Timeout) ->
     Ref = make_ref(),
     ok = esqlite3_nif:column_names(Stmt, Ref, self()),
@@ -308,11 +308,11 @@ column_names(Stmt, Timeout) ->
 
 %% @doc Return the column types of the prepared statement.
 %%
--spec column_types(statement()) -> tuple(atom()).
+-spec column_types(statement()) -> {atom()}.
 column_types(Stmt) ->
     column_types(Stmt, ?DEFAULT_TIMEOUT).
 
--spec column_types(statement(), timeout()) -> tuple(atom()).
+-spec column_types(statement(), timeout()) -> {atom()}.
 column_types(Stmt, Timeout) ->
     Ref = make_ref(),
     ok = esqlite3_nif:column_types(Stmt, Ref, self()),


### PR DESCRIPTION
Compiling the library with OTP 18.0, I got the following error:

```
[jazzyb@elixir ~/share/esqlite]$ gmake test
./rebar compile
==> esqlite (compile)
src/esqlite3.erl:315: type tuple(_) undefined
Makefile:16: recipe for target 'compile' failed
gmake: *** [compile] Error 1
```

Changing `tuple(atom())` to the equivalent `{atom()}` fixes the build.

See:  http://www.erlang.org/documentation/doc-5.8.5/doc/reference_manual/typespec.html