### PR TITLE
Add insert_statement function.

### DIFF
--- a/c_src/esqlite3_nif.c
+++ b/c_src/esqlite3_nif.c
@@ -62,7 +62,8 @@ typedef enum {
     cmd_column_types,
     cmd_close,
     cmd_stop,
-    cmd_insert
+    cmd_insert,
+    cmd_insert_statement,
 } command_type;
 
 typedef struct {
@@ -616,6 +617,35 @@ do_close(ErlNifEnv *env, esqlite_connection *conn, const ERL_NIF_TERM arg)
 }
 
 static ERL_NIF_TERM
+do_insert_statement(ErlNifEnv *env, sqlite3 *db, sqlite3_stmt *stmt)
+{
+  int rc = sqlite3_step(stmt);
+
+  if(rc == SQLITE_ROW)
+    return make_row(env, stmt);
+  if(rc == SQLITE_BUSY)
+    return make_atom(env, "$busy");
+
+  if(rc == SQLITE_DONE) {
+    /*
+     * Automatically reset the statement after a done so
+     * column_names will work after the statement is done.
+     *
+     * Not resetting the statement can lead to vm crashes.
+     */
+    sqlite3_reset(stmt);
+
+    sqlite3_int64 last_rowid = sqlite3_last_insert_rowid(db);
+    ERL_NIF_TERM last_rowid_term = enif_make_int64(env, last_rowid);
+    return make_ok_tuple(env, last_rowid_term);
+  }
+
+  /* We use prepare_v2, so any error code can be returned. */
+  return make_sqlite3_error_tuple(env, rc, db);
+}
+
+
+static ERL_NIF_TERM
 evaluate_command(esqlite_command *cmd, esqlite_connection *conn)
 {
     switch(cmd->type) {
@@ -639,8 +669,10 @@ evaluate_command(esqlite_command *cmd, esqlite_connection *conn)
 	    return do_column_types(cmd->env, cmd->stmt);
     case cmd_close:
 	    return do_close(cmd->env, conn, cmd->arg);
-	case cmd_insert:
+    case cmd_insert:
 	    return do_insert(cmd->env, conn, cmd->arg);
+    case cmd_insert_statement:
+      return do_insert_statement(cmd->env, conn->db, cmd->stmt);
     default:
 	    return make_error_tuple(cmd->env, "invalid_command");
     }
@@ -844,6 +876,43 @@ esqlite_insert(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
     return push_command(env, db, cmd);
 }
 
+/*
+ * Insert with a prepared statement.  Returns lastrowid
+ */
+static ERL_NIF_TERM
+esqlite_insert_statement(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    esqlite_statement *stmt;
+    esqlite_command *cmd = NULL;
+    ErlNifPid pid;
+
+    if(argc != 3)
+	    return enif_make_badarg(env);
+    if(!enif_get_resource(env, argv[0], esqlite_statement_type, (void **) &stmt))
+	    return enif_make_badarg(env);
+    if(!enif_is_ref(env, argv[1]))
+	    return make_error_tuple(env, "invalid_ref");
+    if(!enif_get_local_pid(env, argv[2], &pid))
+	    return make_error_tuple(env, "invalid_pid");
+    if(!stmt->statement)
+	    return make_error_tuple(env, "no_prepared_statement");
+
+    cmd = command_create();
+    if(!cmd)
+	   return make_error_tuple(env, "command_create_failed");
+
+    cmd->type = cmd_insert_statement;
+    cmd->ref = enif_make_copy(cmd->env, argv[1]);
+    cmd->pid = pid;
+    cmd->stmt = stmt->statement;
+
+    if(!stmt->connection)
+	    return make_error_tuple(env, "no_connection");
+    if(!stmt->connection->commands)
+	    return make_error_tuple(env, "no_command_queue");
+
+    return push_command(env, stmt->connection, cmd);
+}
 
 /*
  * Prepare the sql statement
@@ -1141,7 +1210,8 @@ static ErlNifFunc nif_funcs[] = {
     {"bind", 4, esqlite_bind},
     {"column_names", 3, esqlite_column_names},
     {"column_types", 3, esqlite_column_types},
-    {"close", 3, esqlite_close}
+    {"close", 3, esqlite_close},
+    {"insert_statement", 3, esqlite_insert_statement}
 };
 
 ERL_NIF_INIT(esqlite3_nif, nif_funcs, on_load, on_reload, on_upgrade, NULL);

--- a/src/esqlite3.erl
+++ b/src/esqlite3.erl
@@ -33,7 +33,8 @@
          fetchall/1,
          column_names/1, column_names/2,
          column_types/1, column_types/2,
-         close/1, close/2]).
+         close/1, close/2,
+         insert_statement/1, insert_statement/2]).
 
 -export([q/2, q/3, map/3, foreach/3]).
 
@@ -270,6 +271,20 @@ step(Stmt) ->
 step(Stmt, Timeout) ->
     Ref = make_ref(),
     ok = esqlite3_nif:step(Stmt, Ref, self()),
+    receive_answer(Ref, Timeout).
+
+%% @doc steps a prepared statement and returns the last inserted rowid
+%%
+%% @spec insert_statement(prepared_statement()) -> tuple()
+insert_statement(Stmt) ->
+    insert_statement(Stmt, ?DEFAULT_TIMEOUT).
+
+%% @doc steps a prepared statement and returns the last inserted rowid
+%%
+%% @spec insert_statement(prepared_statement(), timeout()) -> tuple()
+insert_statement(Stmt, Timeout) ->
+    Ref = make_ref(),
+    ok = esqlite3_nif:insert_statement(Stmt, Ref, self()),
     receive_answer(Ref, Timeout).
 
 %% @doc Reset the prepared statement back to its initial state.

--- a/src/esqlite3_nif.erl
+++ b/src/esqlite3_nif.erl
@@ -33,7 +33,8 @@
     bind/4,
     column_names/3,
     column_types/3,
-    close/3
+    close/3,
+    insert_statement/3
 ]).
 
 -on_load(init/0).
@@ -136,5 +137,8 @@ close(_Db, _Ref, _Dest) ->
 insert(_Db, _Ref, _Dest, _Sql) ->
     exit(nif_library_not_loaded).
 
-
-
+%% @doc Inserts a record using a prepared statement.  Returns the rowid
+%%
+%% @spec step(statement(), reference(), pid()) -> {ok, integer()} | {error, message()}
+insert_statement(_Stmt, _Ref, _Dest) ->
+    exit(nif_library_not_loaded).

--- a/test/esqlite_test.erl
+++ b/test/esqlite_test.erl
@@ -325,4 +325,22 @@ sqlite_source_id_test() ->
     {sqlite_source_id} =  esqlite3:column_names(Stmt),
     ?assertEqual({row, {<<"2015-01-30 14:30:45 7757fc721220e136620a89c9d28247f28bbbc098">>}}, esqlite3:step(Stmt)),
     ok.
-    
+
+insert_statement_test() ->
+    {ok, Db} = esqlite3:open(":memory:"),
+
+    ok = esqlite3:exec("begin;", Db),
+    ok = esqlite3:exec("create table test_table(id integer primary key, one int);", Db),
+    ok = esqlite3:exec("commit;", Db),
+
+    %% Create a prepared statement
+    {ok, Statement} = esqlite3:prepare("insert into test_table (one) values(?1);", Db),
+
+    %% Insert some values
+    esqlite3:bind(Statement, [one, 100]),
+    {ok, Id1} = esqlite3:insert_statement(Statement),
+    esqlite3:bind(Statement, [one, 200]),
+    {ok, Id2} = esqlite3:insert_statement(Statement),
+
+    ?assertEqual([{Id1}, {Id2}],
+        esqlite3:q("select id from test_table;", Db)).


### PR DESCRIPTION
An application I'm working on really needs to use prepared statements, and also needs to know the ID of the row that was inserted by those statements.

The current insert function gets me half way there, but it appears to accept a SQL string, which would leave me open to SQL injection without careful sanitization.  So, I've added an insert_statement function.

insert_statement is basically a combination between insert & step - it returns the last inserted rowid after stepping a prepared statement. This allows us to get the last rowid when using prepared statements.

I'm far from an Erlang expert (my applicaiton is written in Elixir) and it's been a while since I've done any C, so it'd be good to make sure I've not done anything incorrect.  I'm also open to changing names and re-arranging things, please let me know if you're not happy with anything.