### PR TITLE
Add Erlang versions to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,9 @@ otp_release:
   - R16B03
   - R15B01
   - 17.0
+  - 17.1
+  - 17.3
+  - 17.4
+  - 17.5
+  - 18.0
 script: "rebar compile eunit"


### PR DESCRIPTION
Added Erlang versions 17.1, 17.2, 17.3, 17.4 and 17.5 to `.travis.yml`
