### PR TITLE
Test NULL binding

### DIFF
--- a/test/esqlite_test.erl
+++ b/test/esqlite_test.erl
@@ -80,6 +80,8 @@ bind_test() ->
     esqlite3:step(Statement),
     esqlite3:bind(Statement, [{blob, [<<"eleven">>, 0]}, 12]), % iolist bound as blob with trailing eos.
     esqlite3:step(Statement),
+    esqlite3:bind(Statement, ["empty", undefined]), % 'undefined' is converted to SQL null
+    esqlite3:step(Statement),
 
     %% int64
     esqlite3:bind(Statement, [int64, 308553449069486081]),
@@ -106,6 +108,8 @@ bind_test() ->
         esqlite3:q("select one, two from test_table where two = 10", Db)),
     ?assertEqual([{{blob, <<$e,$l,$e,$v,$e,$n,0>>}, 12}], 
         esqlite3:q("select one, two from test_table where two = 12", Db)),
+    ?assertEqual([{<<"empty">>, undefined}], 
+        esqlite3:q("select one, two from test_table where two is null", Db)),
 
     ?assertEqual([{<<"int64">>, 308553449069486081}], 
         esqlite3:q("select one, two from test_table where one = 'int64';", Db)),


### PR DESCRIPTION
This tests binding an SQL NULL value by passing in an 'undefined' atom
in Erlang in  place of an SQL NULL. It also verifies that the returned NULL
is mapped to 'undefined' when returned via a query.
