### PR TITLE
fix type specs for the q/2 and q/3 functions

### DIFF
--- a/src/esqlite3.erl
+++ b/src/esqlite3.erl
@@ -42,7 +42,7 @@
 %%
 -type connection() :: {connection, reference(), term()}.
 -type statement() :: {statement, term(), connection()}.
--type sql() :: iolist().
+-type sql() :: iodata().
 
 %% @doc Opens a sqlite3 database mentioned in Filename.
 %%
@@ -68,12 +68,12 @@ open(Filename, Timeout) ->
     end.
 
 %% @doc Execute a sql statement, returns a list with tuples.
--spec q(sql(), connection()) -> list(tuple()).
+-spec q(sql(), connection()) -> list(tuple()) | {error, term()}.
 q(Sql, Connection) ->
     q(Sql, [], Connection).
 
 %% @doc Execute statement, bind args and return a list with tuples as result.
--spec q(sql(), list(), connection()) -> list(tuple()).
+-spec q(sql(), list(), connection()) -> list(tuple()) | {error, term()}.
 q(Sql, [], Connection) ->
     case prepare(Sql, Connection) of
         {ok, Statement} ->


### PR DESCRIPTION
When using `dialyzer` in https://github.com/mmmries/sqlitex I was getting errors because we are sometimes passing in sql as a `binary()`. We were also pattern matching on `{error, _reason}` clauses coming back from `q/2` and `q/3`.

I've verified that these functions do sometimes return `{error, _reason}` tuples and that passing in binary SQL statements works just fine. So I'm suggesting these updates to the typespecs.