### PR TITLE
Update version

### DIFF
--- a/src/esqlite.app.src
+++ b/src/esqlite.app.src
@@ -1,7 +1,7 @@
 {application, esqlite,
  [
   {description, "sqlite nif interface"},
-  {vsn, "0.2.3"},
+  {vsn, "0.2.5"},
   {modules, [esqlite3, esqlite3_nif]},
   {registered, []},
   {maintainers, ["Aleph Archives", "Qing Liang <qing.liang.cn@gmail.com>"]},


### PR DESCRIPTION
There hasn't been a version bump in about [2 years](https://github.com/mmzeeman/esqlite/blame/067166b965a45fd1e75821888d42e31239773821/src/esqlite.app.src#L3) so i thought now's as good a time as any.

The rebar and hex.pm versions have diverged at some point in the
last two years, so i bumped to 0.2.5 to get them to the same
number.