### PR TITLE
Bump version

### DIFF
--- a/src/esqlite.app.src
+++ b/src/esqlite.app.src
@@ -1,7 +1,7 @@
 {application, esqlite,
  [
   {description, "sqlite nif interface"},
-  {vsn, "0.2.5"},
+  {vsn, "0.3.0"},
   {modules, [esqlite3, esqlite3_nif]},
   {registered, []},
   {maintainers, ["Aleph Archives", "Qing Liang <qing.liang.cn@gmail.com>"]},


### PR DESCRIPTION
With 1cb801d0a802870bcfc2a91e639d3414597b1fe7 comes a
fix for a remote execution vuln. I think this warrants a minor
version bump