### PR TITLE
Update docs for releasing package on hex.pm

### DIFF
--- a/hex.pm.md
+++ b/hex.pm.md
@@ -2,7 +2,12 @@
 
 Releases of [esqlite on hex.pm](https://hex.pm/packages/esqlite) are managed by Connor Rigby ([@connorrigby](https://github.com/connorrigby)).
 
-To make a release:
+## Setup
+1. Install rebar3
+2. [Install hex plugin](https://hex.pm/docs/rebar3_usage#installation)
+3. Run `rebar3 update`.
+
+## Make a Release
 
 1. Increment the version number in `src/esqlite.app.src` as appropriate.
 2. Run `rebar3 ct` to ensure that the build is good.

--- a/src/esqlite.app.src
+++ b/src/esqlite.app.src
@@ -4,7 +4,6 @@
   {vsn, "0.4.0"},
   {modules, [esqlite3, esqlite3_nif]},
   {registered, []},
-  {maintainers, ["Aleph Archives", "Qing Liang <qing.liang.cn@gmail.com>"]},
   {licenses, ["Apache"]},
   {links, [{"Github", "https://github.com/mmzeeman/esqlite"}]},
   {include_files, ["Makefile"]},


### PR DESCRIPTION
Hello @mmzeeman, i planed on making a release on hex.pm today, but it looks like some of the hex publishing docs/requirements have changed. This PR allows hex.pm publishing again.