### PR TITLE
Update Makefile to use `rebar3` instead of `rebar`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .rebar
-rebar
+.rebar3
+rebar3
 ebin
 priv
 .eunit/*
@@ -8,3 +9,4 @@ priv
 *~
 _build
 c_src/**/*.d
+erl_crash.dump

--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,33 @@
 PROJECT = esqlite
 DIALYZER = dialyzer
 
-REBAR := $(shell which rebar 2>/dev/null || echo ./rebar)
-REBAR_URL := https://github.com/downloads/basho/rebar/rebar
+REBAR3 := $(shell which rebar3 2>/dev/null || echo ./rebar3)
+REBAR3_VERSION := 3.10.0
+REBAR3_URL := https://github.com/erlang/rebar3/releases/download/$(REBAR3_VERSION)/rebar3
 
 all: compile
 
-./rebar:
-	erl -noshell -s inets start -s ssl start \
-        -eval '{ok, saved_to_file} = httpc:request(get, {"$(REBAR_URL)", []}, [], [{stream, "./rebar"}])' \
-        -s inets stop -s init stop
-	chmod +x ./rebar
+./rebar3:
+	wget $(REBAR3_URL)
+	chmod +x ./rebar3
 
-compile: rebar
-	$(REBAR) compile
+compile: rebar3
+	$(REBAR3) compile
 
 test: compile
-	$(REBAR) eunit
+	$(REBAR3) eunit
 
-clean: rebar
-	$(REBAR) clean
+clean: rebar3
+	$(REBAR3) clean
 
-distclean: 
-	rm $(REBAR)
+distclean:
+	rm $(REBAR3)
 
-# dializer 
+# dializer
 
 build-plt:
 	@$(DIALYZER) --build_plt --output_plt .$(PROJECT).plt \
-		--apps kernel stdlib 
+		--apps kernel stdlib
 
 dialyze:
 	@$(DIALYZER) --src src --plt .$(PROJECT).plt --no_native \


### PR DESCRIPTION
@mmzeeman This is just a small update to make the `makefile` use `rebar3` 