### PR TITLE
Fix ESQLITE_USE_SYSTEM

### DIFF
--- a/c_src/esqlite3_nif.c
+++ b/c_src/esqlite3_nif.c
@@ -22,7 +22,7 @@
 #include <string.h>
 #include <stdio.h>
 
-#include "sqlite3.h"
+#include <sqlite3.h>
 #include "queue.h"
 
 #define MAX_ATOM_LENGTH 255 /* from atom.h, not exposed in erlang include */
@@ -989,7 +989,7 @@ esqlite_get_autocommit(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
     cmd->ref = enif_make_copy(cmd->env, argv[1]);
     cmd->pid = pid;
 
-    return push_command(env, db, cmd);   
+    return push_command(env, db, cmd);
 }
 
 /*

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -12,8 +12,8 @@ DrvLdFlags =
 
 {NifSources, LdEnv, CFlagsExt} =
     case os:getenv("ESQLITE_USE_SYSTEM") of
-        NotDefined when NotDefined == false; NotDefined == [] -> {NifStaticSources, [], []};
-        _Defined -> {NifSharedSources, [{"DRV_LDFLAGS", DrvLdFlags}], " -Ic_src/sqlite3"}
+        NotDefined when NotDefined == false; NotDefined == [] -> {NifStaticSources, [], " -Ic_src/sqlite3"};
+        _Defined -> {NifSharedSources, [{"DRV_LDFLAGS", DrvLdFlags}], []}
     end.
 
 CFlags =


### PR DESCRIPTION
This fixes the logic for setting the include directory for the sqlite header file. 

CC @mmzeeman 