### PR TITLE
Interrupt running queries on timeout

### DIFF
--- a/c_src/esqlite3_nif.c
+++ b/c_src/esqlite3_nif.c
@@ -1215,6 +1215,20 @@ esqlite_column_types(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
     return push_command(env, conn, cmd);
 }
 
+static ERL_NIF_TERM
+esqlite_interrupt(ErlNifEnv *env, int argc, const ERL_NIF_TERM argv[])
+{
+    esqlite_connection *conn;
+
+    if(!enif_get_resource(env, argv[0], esqlite_connection_type, (void **) &conn))
+        return enif_make_badarg(env);
+
+    esqlite_connection *db = (esqlite_connection *) conn;
+    sqlite3_interrupt(db->db);
+
+    return enif_make_atom(env, "ok");
+}
+
 /*
  * Close the database
  */
@@ -1293,6 +1307,7 @@ static ErlNifFunc nif_funcs[] = {
     {"bind", 5, esqlite_bind},
     {"column_names", 4, esqlite_column_names},
     {"column_types", 4, esqlite_column_types},
+    {"interrupt", 1, esqlite_interrupt},
     {"close", 3, esqlite_close}
 };
 

--- a/src/esqlite3_nif.erl
+++ b/src/esqlite3_nif.erl
@@ -35,6 +35,7 @@
          bind/5,
          column_names/4,
          column_types/4,
+         interrupt/1,
          close/3
         ]).
 
@@ -129,12 +130,17 @@ column_names(_Db, _Stmt, _Ref, _Dest) ->
 column_types(_Db, _Stmt, _Ref, _Dest) ->
     erlang:nif_error(nif_library_not_loaded).
 
+%% @doc Abort any pending database operation.
+%%
+%% @spec interrupt(connection()) -> ok
+interrupt(_Db) ->
+    erlang:nif_error(nif_library_not_loaded).
+
 %% @doc Close the connection.
 %%
 %% @spec close(connection(), reference(), pid()) -> ok | {error, message()}
 close(_Db, _Ref, _Dest) ->
     erlang:nif_error(nif_library_not_loaded).
-
 
 %% @doc Insert record
 %%


### PR DESCRIPTION
If a timeout occurs, it leaves the current (long) query running. Subsequent queries
or an attempt to close the connection will block until the query is finished. If new
requests also time out and yet more requests arrive, it is easy to lock the database.

This commit communicates an intterupt (https://sqlite.org/c3ref/interrupt.html) to
the currently running thread to make it abort the running query timely.