### PR TITLE
Extend cflags for specific architectures

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -30,10 +30,10 @@ CFlags =
             "-flat_namespace -undefined suppress $ERL_LDFLAGS"},
 
         {"solaris", "CFLAGS",
-            "-std=c99"},
+            "$CFLAGS -std=c99"},
 
         {"linux", "CFLAGS",
-            "-std=c11"},
+            "$CFLAGS -std=c11"},
 
         {"CFLAGS", CFlags}
     ] ++ LdEnv},


### PR DESCRIPTION
Previously specific archs overwrote the cflags variable instead of
extending it.

This causes issue cross-compiling on certain hosts for certain targets.