### PR TITLE
Add function to get the last insert rowid

### DIFF
--- a/src/esqlite3.erl
+++ b/src/esqlite3.erl
@@ -393,7 +393,7 @@ last_insert_rowid(Connection) ->
 last_insert_rowid({connection, _Ref, Connection}, Timeout) ->
     Ref = make_ref(),
     ok = esqlite3_nif:last_insert_rowid(Connection, Ref, self()),
-    receive_answer(Ref, Timeout).
+    receive_answer(Connection, Ref, Timeout).
 
 %% @doc Get autocommit
 %% @doc Check if the connection is in auto-commit mode.

--- a/src/esqlite3.erl
+++ b/src/esqlite3.erl
@@ -26,6 +26,7 @@
          exec/2, exec/3,
          changes/1, changes/2,
          insert/2,
+         last_insert_rowid/1,
          get_autocommit/1,
          get_autocommit/2,
          prepare/2, prepare/3,
@@ -322,6 +323,20 @@ insert(Sql, Connection) ->
 insert(Sql, {connection, _Ref, Connection}, Timeout) ->
     Ref = make_ref(),
     ok = esqlite3_nif:insert(Connection, Ref, self(), Sql),
+    receive_answer(Ref, Timeout).
+
+%% @doc Get the last insert rowid, using the default timeout.
+%%
+%% @spec last_insert_rowid(connection()) -> {ok, integer()} | {error, error_message()}
+last_insert_rowid(Connection) ->
+    last_insert_rowid(Connection, ?DEFAULT_TIMEOUT).
+
+%% @doc Get the last insert rowid.
+%%
+%% @spec last_insert_rowid(connection(), timeout()) -> {ok, integer()} | {error, error_message()}
+last_insert_rowid({connection, _Ref, Connection}, Timeout) ->
+    Ref = make_ref(),
+    ok = esqlite3_nif:last_insert_rowid(Connection, Ref, self()),
     receive_answer(Ref, Timeout).
 
 %% @doc Get autocommit

--- a/src/esqlite3_nif.erl
+++ b/src/esqlite3_nif.erl
@@ -27,6 +27,7 @@
          exec/4,
          changes/3,
          insert/4,
+         last_insert_rowid/3,
          get_autocommit/3,
          prepare/4,
          multi_step/5,
@@ -140,6 +141,12 @@ close(_Db, _Ref, _Dest) ->
 %%
 %% @spec insert(connection(), Ref::reference(), Dest::pid(), string()) -> {ok, integer()} | {error, message()}
 insert(_Db, _Ref, _Dest, _Sql) ->
+    erlang:nif_error(nif_library_not_loaded).
+
+%% @doc Get the last insert rowid.
+%%
+%% @spec insert(connection(), Ref::reference(), Dest::pid()) -> {ok, integer()} | {error, message()}
+last_insert_rowid(_Db, _Ref, _Dest) ->
     erlang:nif_error(nif_library_not_loaded).
 
 %% @doc Get automcommit

--- a/test/esqlite_test.erl
+++ b/test/esqlite_test.erl
@@ -31,6 +31,15 @@ get_autocommit_test() ->
     true = esqlite3:get_autocommit(Db),
     ok.
 
+last_insert_rowid_test() ->
+    {ok, Db} = esqlite3:open(":memory:"),
+    ok = esqlite3:exec("CREATE TABLE test (id INTEGER PRIMARY KEY, val STRING);", Db),
+    ok = esqlite3:exec("INSERT INTO test (val) VALUES ('this is a test');", Db),
+    {ok, 1} = esqlite3:last_insert_rowid(Db),
+    ok = esqlite3:exec("INSERT INTO test (val) VALUES ('this is another test');", Db),
+    {ok, 2} = esqlite3:last_insert_rowid(Db),
+    ok.
+
 update_hook_test() ->
     {ok, Db} = esqlite3:open(":memory:"),
     ok = esqlite3:set_update_hook(self(), Db),


### PR DESCRIPTION
Hello. I don't really know what I'm doing, but I think this makes sense? Mostly just copied from the `get_autocommit` and `insert` implementations.

I just want to expose this Sqlite function so I can get the last insert ID. Had considered a) using the existing `insert` function, but this doesn't support using a prepared statement/binding, or b) using a transaction with the `INSERT` and `SELECT last_insert_rowid()`, but that seems unnecessarily convoluted.

Conscious that this implementation might not have the same atomicity guarantees as these two options though?