### PR TITLE
Add specs docs and refactor

### DIFF
--- a/c_src/esqlite3_nif.c
+++ b/c_src/esqlite3_nif.c
@@ -416,20 +416,24 @@ bind_cell(ErlNifEnv *env, const ERL_NIF_TERM cell, sqlite3_stmt *stmt, unsigned 
     const ERL_NIF_TERM* tuple;
 
     if(enif_get_int(env, cell, &the_int))
-	    return sqlite3_bind_int(stmt, i, the_int);
+        return sqlite3_bind_int(stmt, i, the_int);
 
     if(enif_get_int64(env, cell, &the_long_int))
         return sqlite3_bind_int64(stmt, i, the_long_int);
 
     if(enif_get_double(env, cell, &the_double))
-	    return sqlite3_bind_double(stmt, i, the_double);
+        return sqlite3_bind_double(stmt, i, the_double);
 
     if(enif_get_atom(env, cell, the_atom, sizeof(the_atom), ERL_NIF_LATIN1)) {
-	    if(strcmp("undefined", the_atom) == 0) {
-	       return sqlite3_bind_null(stmt, i);
-	    }
+        if(strncmp("undefined", the_atom, strlen("undefined")) == 0) {
+            return sqlite3_bind_null(stmt, i);
+        }  
 
-	    return sqlite3_bind_text(stmt, i, the_atom, strlen(the_atom), SQLITE_TRANSIENT);
+        if(strncmp("null", the_atom, strlen("null")) == 0) {
+            return sqlite3_bind_null(stmt, i);
+        }
+
+        return sqlite3_bind_text(stmt, i, the_atom, strlen(the_atom), SQLITE_TRANSIENT);
     }
 
     /* Bind as text assume it is utf-8 encoded text */
@@ -448,7 +452,7 @@ bind_cell(ErlNifEnv *env, const ERL_NIF_TERM cell, sqlite3_stmt *stmt, unsigned 
                 /* with a iolist as argument */
                 if(enif_inspect_iolist_as_binary(env, tuple[1], &the_blob)) {
                     /* kaboom... get the blob */
-	                return sqlite3_bind_blob(stmt, i, the_blob.data, the_blob.size, SQLITE_TRANSIENT);
+                    return sqlite3_bind_blob(stmt, i, the_blob.data, the_blob.size, SQLITE_TRANSIENT);
                 }
             }
         }

--- a/src/esqlite.app.src
+++ b/src/esqlite.app.src
@@ -1,7 +1,7 @@
 {application, esqlite,
  [
   {description, "sqlite nif interface"},
-  {vsn, "0.5.0"},
+  {vsn, "0.5.1"},
   {modules, [esqlite3, esqlite3_nif]},
   {registered, []},
   {licenses, ["Apache"]},

--- a/src/esqlite3_nif.erl
+++ b/src/esqlite3_nif.erl
@@ -50,7 +50,7 @@ init() ->
 
 %% @doc Start a low level thread which will can handle sqlite3 calls.
 %%
-%% @spec start() -> {ok, connection()} | {error, msg()}
+-spec start() -> {ok, esqlite:connection()} | {error, any()}.
 start() ->
     erlang:nif_error(nif_library_not_loaded).
 
@@ -59,8 +59,7 @@ start() ->
 %% Sends an asynchronous open command over the connection and returns
 %% ok immediately. When the database is opened
 %%
-%%  @spec open(connection(), reference(), pid(), string()) -> ok | {error, message()}
-
+-spec open(esqlite:connection(), reference(), pid(), string()) -> ok | {error, any()}.
 open(_Db, _Ref, _Dest, _Filename) ->
     erlang:nif_error(nif_library_not_loaded).
 
@@ -75,7 +74,7 @@ set_update_hook(_Db, _Ref, _Dest, _Pid) ->
 %% When the statement is executed Dest will receive message {Ref, answer()}
 %% with answer() integer | {error, reason()}
 %%
-%%  @spec exec(connection(), Ref::reference(), Dest::pid(), string()) -> ok | {error, message()}
+-spec exec(esqlite:connection(), reference(), pid(), string()) -> ok | {error, any()}.
 exec(_Db, _Ref, _Dest, _Sql) ->
     erlang:nif_error(nif_library_not_loaded).
 
@@ -89,61 +88,60 @@ changes(_Db, _Ref, _Dest) ->
 
 %% @doc
 %%
-%% @spec prepare(connection(), reference(), pid(), string()) -> ok | {error, message()}
+-spec prepare(esqlite:connection(), reference(), pid(), string()) -> ok | {error, any()}.
 prepare(_Db, _Ref, _Dest, _Sql) ->
     erlang:nif_error(nif_library_not_loaded).
 
 %% @doc
 %%
-%% @spec multi_step(statement(), pos_integer(), reference(), pid()) -> {term(), list(tuple)} | {error, message()}
+-spec multi_step(esqlite:connection(), esqlite:statement(), pos_integer(), reference(), pid()) -> ok | {error, any()}.
 multi_step(_Db, _Stmt, _Chunk_Size, _Ref, _Dest) ->
     erlang:nif_error(nif_library_not_loaded).
 
 %% @doc
 %%
-%% @spec reset(statement(), reference(), pid()) -> ok | {error, message()}
+-spec reset(esqlite:connection(), esqlite:statement(), reference(), pid()) -> ok | {error, any()}.
 reset(_Db, _Stmt, _Ref, _Dest) ->
     erlang:nif_error(nif_library_not_loaded).
 
 %% @doc
 %%
-%%
+-spec finalize(esqlite:connection(), esqlite:statement(), reference(), pid()) -> ok | {error, any()}.
 finalize(_Db, _Stmt, _Ref, _Dest) ->
     erlang:nif_error(nif_library_not_loaded).
 
 %% @doc Bind parameters to a prepared statement.
 %%
-%% @spec bind(connection(), statement(), reference(), pid(), []) -> ok | {error, message()}
+-spec bind(esqlite:connection(), esqlite:statement(), reference(), pid(), list(any())) -> ok | {error, any()}.
 bind(_Db, _Stmt, _Ref, _Dest, _Args) ->
     erlang:nif_error(nif_library_not_loaded).
 
 %% @doc Retrieve the column names of the prepared statement
 %%
-%% @spec column_names(connection(), statement(), reference(), pid()) -> {ok, tuple()} | {error, message()}
+-spec column_names(esqlite:connection(), esqlite:statement(), reference(), pid()) -> ok | {error, any()}.
 column_names(_Db, _Stmt, _Ref, _Dest) ->
     erlang:nif_error(nif_library_not_loaded).
 
 %% @doc Retrieve the column types of the prepared statement
 %%
-%% @spec column_types(connection(), statement(), reference(), pid()) -> {ok, tuple()} | {error, message()}
+-spec column_types(esqlite:connection(), esqlite:statement(), reference(), pid()) -> ok | {error, any()}.
 column_types(_Db, _Stmt, _Ref, _Dest) ->
     erlang:nif_error(nif_library_not_loaded).
 
 %% @doc Close the connection.
 %%
-%% @spec close(connection(), reference(), pid()) -> ok | {error, message()}
+-spec close(esqlite:connection(), reference(), pid()) -> ok | {error, any()}.
 close(_Db, _Ref, _Dest) ->
     erlang:nif_error(nif_library_not_loaded).
 
-
 %% @doc Insert record
 %%
-%% @spec insert(connection(), Ref::reference(), Dest::pid(), string()) -> {ok, integer()} | {error, message()}
+-spec insert(esqlite:connection(), reference(), pid(), esqlite:sql()) -> ok | {error, any()}.
 insert(_Db, _Ref, _Dest, _Sql) ->
     erlang:nif_error(nif_library_not_loaded).
 
 %% @doc Get automcommit
 %%
-%% @spec get_autocommit(connection(), Ref::reference(), Dest::pid()) -> true | false
+-spec get_autocommit(esqlite:connection(), reference(), pid()) -> ok | {error, any()}.
 get_autocommit(_Db, _Ref, _Dest) ->
     erlang:nif_error(nif_library_not_loaded).

--- a/test/esqlite_test.erl
+++ b/test/esqlite_test.erl
@@ -422,11 +422,14 @@ sqlite_source_id_test() ->
 
 garbage_collect_test() ->
     F = fun() ->
-        {ok, Db} = esqlite3:open(":memory:"),
-        [] = esqlite3:q("create table test(one, two, three)", Db),
-        {ok, Stmt} = esqlite3:prepare("select * from test", Db),
-        '$done' = esqlite3:step(Stmt)
-    end,
+                {ok, Db} = esqlite3:open(":memory:"),
+                [] = esqlite3:q("create table test(one, two, three)", Db),
+                [] = esqlite3:q("insert into test values(1, '2', 3.0)", Db), 
+                {ok, Stmt} = esqlite3:prepare("select * from test", Db),
+                {row, {1, <<"2">>, 3.0}} = esqlite3:step(Stmt),
+                '$done' = esqlite3:step(Stmt),
+                ok = esqlite3:close(Db)
+        end,
 
     [spawn(F) || _X <- lists:seq(0,30)],
     receive after 500 -> ok end,
@@ -437,6 +440,4 @@ garbage_collect_test() ->
     erlang:garbage_collect(),
 
     ok.
-
-
 


### PR DESCRIPTION
- Cleanup old @spec definitions in comments. Use current -spec definitions instead.
- Changed default timeout to `infinity`. Normally calls should return quickly. To be able to deal with stale messages in the processes inbox a `flush` call has been added.
- Various small refactors

