### PR TITLE
Bump 3.37.2

### DIFF
--- a/c_src/sqlite3/sqlite3.h
+++ b/c_src/sqlite3/sqlite3.h
@@ -146,9 +146,9 @@ extern "C" {
 ** [sqlite3_libversion_number()], [sqlite3_sourceid()],
 ** [sqlite_version()] and [sqlite_source_id()].
 */
-#define SQLITE_VERSION        "3.37.1"
-#define SQLITE_VERSION_NUMBER 3037001
-#define SQLITE_SOURCE_ID      "2021-12-30 15:30:28 378629bf2ea546f73eee84063c5358439a12f7300e433f18c9e1bddd948dea62"
+#define SQLITE_VERSION        "3.37.2"
+#define SQLITE_VERSION_NUMBER 3037002
+#define SQLITE_SOURCE_ID      "2022-01-06 13:25:41 872ba256cbf61d9290b571c0e6d82a20c224ca3ad82971edc46b29818d5d17a0"
 
 /*
 ** CAPI3REF: Run-Time Library Version Numbers

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -58,5 +58,8 @@ CFlags =
             race_conditions,
             underspecs
         ]}
-    ]}
+    ]},
+
+    {hex, [{doc, edoc}]}
+
 ].

--- a/src/esqlite3.erl
+++ b/src/esqlite3.erl
@@ -1,9 +1,6 @@
 %% @author Maas-Maarten Zeeman <mmzeeman@xs4all.nl>
-%% @copyright 2011 - 2017 Maas-Maarten Zeeman
-
+%% @copyright 2011 - 2022 Maas-Maarten Zeeman
 %% @doc Erlang API for sqlite3 databases
-
-%% Copyright 2011 - 2017 Maas-Maarten Zeeman
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -422,7 +419,6 @@ last_insert_rowid(#connection{raw_connection=RawConnection}, Timeout) ->
     ok = esqlite3_nif:last_insert_rowid(RawConnection, Ref, self()),
     receive_answer(RawConnection, Ref, Timeout).
 
-%% @doc Get autocommit
 %% @doc Check if the connection is in auto-commit mode.
 %% See: [https://sqlite.org/c3ref/get_autocommit.html] for more details.
 %%

--- a/src/esqlite3_nif.erl
+++ b/src/esqlite3_nif.erl
@@ -1,9 +1,7 @@
 %% @author Maas-Maarten Zeeman <mmzeeman@xs4all.nl>
-%% @copyright 2011 - 2017 Maas-Maarten Zeeman
-
+%% @copyright 2011 - 2022 Maas-Maarten Zeeman
+%%
 %% @doc Low level erlang API for sqlite3 databases
-
-%% Copyright 2011 - 2017 Maas-Maarten Zeeman
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/test/esqlite_test.erl
+++ b/test/esqlite_test.erl
@@ -445,14 +445,14 @@ sqlite_version_test() ->
     {ok, Db} = esqlite3:open(":memory:"),
     {ok, Stmt} = esqlite3:prepare("select sqlite_version() as sqlite_version;", Db),
     {sqlite_version} = esqlite3:column_names(Stmt),
-    ?assertEqual({row, {<<"3.37.1">>}}, esqlite3:step(Stmt)),
+    ?assertEqual({row, {<<"3.37.2">>}}, esqlite3:step(Stmt)),
     ok.
 
 sqlite_source_id_test() ->
     {ok, Db} = esqlite3:open(":memory:"),
     {ok, Stmt} = esqlite3:prepare("select sqlite_source_id() as sqlite_source_id;", Db),
     {sqlite_source_id} = esqlite3:column_names(Stmt),
-    ?assertEqual({row, {<<"2021-12-30 15:30:28 378629bf2ea546f73eee84063c5358439a12f7300e433f18c9e1bddd948dea62">>}},
+    ?assertEqual({row, {<<"2022-01-06 13:25:41 872ba256cbf61d9290b571c0e6d82a20c224ca3ad82971edc46b29818d5d17a0">>}},
                  esqlite3:step(Stmt)),
     ok.
 


### PR DESCRIPTION
Bump sqlite to version 3.37.2.

See: https://www.sqlite.org/releaselog/3_37_2.html