### PR TITLE
Added missing check for inspect_iodata

### DIFF
--- a/test/esqlite_test.erl
+++ b/test/esqlite_test.erl
@@ -29,6 +29,14 @@ close_test() ->
 
     ok.
 
+iodata_test() ->
+    {ok, C} = esqlite3:open(":memory:"),
+    {error, no_iodata} = esqlite3:exec(1000, C),
+    {error, no_iodata} = esqlite3:insert(1000, C),
+
+    ok.
+
+
 open_multiple_same_databases_test() ->
     cleanup(),
 


### PR DESCRIPTION
Fix for continuing to use non iodata results in the c-code. Possibly prevents crashes.