### PR TITLE
Add named parameters support

### DIFF
--- a/CONTRIBUTERS
+++ b/CONTRIBUTERS
@@ -10,3 +10,4 @@
 
 Aleph Archives 
 Qing Liang <qing.liang.cn@gmail.com>
+Dmitry Matveyev <public@greenfork.me>

--- a/src/esqlite3_nif.erl
+++ b/src/esqlite3_nif.erl
@@ -42,6 +42,7 @@
     bind_text/3,
     bind_blob/3,
     bind_null/2,
+    bind_parameter_index/2,
 
     step/1,
 
@@ -192,6 +193,13 @@ bind_blob(_Statement, _Index, _Value) ->
       Index :: integer(),
       Result :: ok | error().
 bind_null(_Statement, _Index) ->
+    erlang:nif_error(nif_library_not_loaded).
+
+-spec bind_parameter_index(Statement, ParameterName) -> Result when
+      Statement :: esqlite3_stmt_ref(),
+      ParameterName :: iodata(),
+      Result :: {ok, integer()} | error.
+bind_parameter_index(_Statement, _ParameterName) ->
     erlang:nif_error(nif_library_not_loaded).
 
 -spec step(Statement) -> StepResult when

--- a/test/esqlite_test.erl
+++ b/test/esqlite_test.erl
@@ -281,6 +281,26 @@ bind_for_queries_test() ->
 
     ok.
 
+named_bind_for_queries_test() ->
+    {ok, Db} = esqlite3:open(":memory:"),
+
+    ok = esqlite3:exec(Db, "begin;"),
+    ok = esqlite3:exec(Db, "create table test_table(one varchar(10), two int);"),
+    ok = esqlite3:exec(Db, "commit;"),
+
+    ?assertEqual([[1]], esqlite3:q(Db, <<"SELECT count(type) FROM sqlite_master WHERE type='table' AND name=:name;">>,
+                                   [{<<":name">>, "test_table"}])),
+    ?assertEqual([[1]], esqlite3:q(Db, <<"SELECT count(type) FROM sqlite_master WHERE type='table' AND name=$name;">>,
+                                   [{"$name", test_table}])),
+    ?assertEqual([[1]], esqlite3:q(Db, <<"SELECT count(type) FROM sqlite_master WHERE type='table' AND name=@name;">>,
+                                   [{"@name", <<"test_table">>}])),
+    ?assertEqual([[1]], esqlite3:q(Db, <<"SELECT count(type) FROM sqlite_master WHERE type='table' AND name=:name;">>,
+                                   #{":name" => test_table})),
+    ?assertEqual([[1]], esqlite3:q(Db, <<"SELECT count(type) FROM sqlite_master WHERE type='table' AND name=:name;">>,
+                                   [{text, ":name", "test_table"}])),
+
+    ok.
+
 column_names2_test() ->
     {ok, Db} = esqlite3:open(":memory:"),
     ok = esqlite3:exec(Db, "begin;"),


### PR DESCRIPTION
Closes  #83

SQLite supports named parameters in either of these forms:
- `$NAME`
- `:NAME`
- `@NAME`

These parameters should be supplied to the query either in a form of a map or as a list, the key is always iodata:
- `#{":myparam" => "value"}`
- `[{"$myparam", 1}]`
- `[{text, "@myparam", "value"}]`