### PR TITLE
Make esqlite work under termux, android

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -41,6 +41,9 @@ CFlags =
         {"solaris", "CFLAGS",
             "$CFLAGS -std=c99"},
 
+        {"android", "DRV_LDFLAGS",
+             "$DRV_LDFLAGS -lm"},
+
         {"linux", "CFLAGS",
             "$CFLAGS -std=c11"},
 


### PR DESCRIPTION
This change allows `dlopen` to find `trunc` et al under Termux, android.

The change seems benign (adding `-lm` should not break where it is superfluous).

Bye,
Kero.