### PR TITLE
Fix linker flags for macOS 26 (Tahoe) beta compatibility

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -34,9 +34,9 @@ CFlags =
                    deprecated_functions]},
 
     {port_env, [
-        %% Default darwin ldflags causes loading of system sqlite. Removed -bundle flag.
+        %% Default darwin ldflags causes loading of system sqlite. Build a dynamiclib.
         {"darwin", "DRV_LDFLAGS",
-            "-flat_namespace -undefined suppress $ERL_LDFLAGS"},
+            "-dynamiclib -undefined dynamic_lookup $ERL_LDFLAGS"},
 
         {"solaris", "CFLAGS",
             "$CFLAGS -std=c99"},


### PR DESCRIPTION
I am running the macOS public beta on my laptop and have noticed that I am no longer able to compile the NIF. Here is the debug output I was getting from rebar.

```
$ DEBUG=1 make test
/opt/homebrew/bin/rebar3 compile
===> Evaluating config script "rebar.config.script"
===> 28.0.2 satisfies the requirement for minimum OTP version 22.0
===> Compile (apps)
===> Expanded command sequence to be run: [app_discovery,install_deps,lock,compile]
===> Running provider: app_discovery
===> Found top-level apps: [esqlite]
        using config: [{src_dirs,["src"]},{lib_dirs,["apps/*","lib/*","."]}]
===> 28.0.2 satisfies the requirement for minimum OTP version 22.0
===> Compile (apps)
===> Not adding provider pc compile from module pc_prv_compile because it already exists from module pc_prv_compile
===> Not adding provider pc clean from module pc_prv_clean because it already exists from module pc_prv_clean
===> Running provider: install_deps
===> Verifying dependencies...
===> Running provider: lock
===> Running provider: compile
===> Compile (apps)
===> Running hooks for compile with configuration:
===>    {pre_hooks, []}.
===> Compile (project_apps)
===> Running hooks for compile in app esqlite (/Users/jtdowney/code/esqlite) with configuration:
===>    {pre_hooks, []}.
===> Running hooks for erlc_compile in app esqlite (/Users/jtdowney/code/esqlite) with configuration:
===>    {pre_hooks, []}.
===> Analyzing applications...
===> Compiling esqlite
===> compile options: {erl_opts, [debug_info]}.
===> files to analyze ["/Users/jtdowney/code/esqlite/src/esqlite3.erl",
                              "/Users/jtdowney/code/esqlite/src/esqlite3_nif.erl"]
===> Running hooks for erlc_compile in app esqlite (/Users/jtdowney/code/esqlite) with configuration:
===>    {provider_hooks, []}.
===>    {post_hooks, []}.
===> Running hooks for app_compile in app esqlite (/Users/jtdowney/code/esqlite) with configuration:
===>    {pre_hooks, []}.
===> Running hooks for app_compile in app esqlite (/Users/jtdowney/code/esqlite) with configuration:
===>    {provider_hooks, []}.
===>    {post_hooks, []}.
===> Running hooks for compile in app esqlite (/Users/jtdowney/code/esqlite) with configuration:
===>    {provider_hooks, [{post, [{pc,compile}]}]}.
===> Running provider: {pc,compile}
===> Running hooks for {pc,compile} with configuration:
===>    {pre_hooks, []}.
===> Linking /Users/jtdowney/code/esqlite/priv/esqlite3_nif.so
===> sh(cc c_src/esqlite3_nif.o c_src/sqlite3/sqlite3.o $LDFLAGS $LDLIBS -flat_namespace -undefined suppress  -L"/Users/jtdowney/.local/share/mise/installs/erlang/28.0.2/lib/erl_interface-5.6/lib" -lei -o /Users/jtdowney/code/esqlite/priv/esqlite3_nif.so)
failed with return code 1 and the following output:
ld: warning: -undefined suppress is deprecated
ld: warning: -undefined suppress is deprecated
Undefined symbols for architecture arm64:
  "_main", referenced from:
      <initial-undefines>
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)

make: *** [compile] Error 1
```

I was able to narrow down the issue to needing to add the `-dynamiclib` flag since macOS was trying to link an executable by default. I also switched `-undefined suppress` to `-undefined dynamic_lookup` since `-undefined suppress` is deprecated. I was able to validate that this change still builds and passes tests on macOS 15.