### PR TITLE
step() can return '$busy' too

### DIFF
--- a/src/esqlite3.erl
+++ b/src/esqlite3.erl
@@ -422,7 +422,7 @@ bind_null(#esqlite3_stmt{stmt=Stmt}, Index) ->
 
 -spec step(Statement) -> StepResult 
     when Statement :: esqlite3_stmt(),
-         StepResult:: row() | '$done' | error().
+         StepResult:: row() | '$done' | '$busy' | error().
 step(#esqlite3_stmt{stmt=Stmt}) ->
     esqlite3_nif:step(Stmt).
 


### PR DESCRIPTION
esqlite3_nif:step() returns '$busy' if sqlite3_step() returned SQLITE_BUSY

Sponsored-by: https://beaverlabs.net